### PR TITLE
Use local variable index instead of global

### DIFF
--- a/dist/Vibrant.js
+++ b/dist/Vibrant.js
@@ -136,7 +136,7 @@ var MMCQ = (function() {
                 histo = vbox.histo;
             if (!vbox._count_set || force) {
                 var npix = 0,
-                    i, j, k;
+                    i, j, k, index;
                 for (i = vbox.r1; i <= vbox.r2; i++) {
                     for (j = vbox.g1; j <= vbox.g2; j++) {
                         for (k = vbox.b1; k <= vbox.b2; k++) {


### PR DESCRIPTION
make index a local variable instead of global in the count function

Re: https://github.com/jariz/vibrant.js/issues/20
