### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@ Vibrant.js is a javascript port of the [awesome Palette class](https://developer
 ## Demo & usage docs
 See the website: http://jariz.github.io/vibrant.js/
 
-##Installing
-####Bower
+## Installing
+#### Bower
 `bower install vibrant`
-####Download
+#### Download
 See our [releases](https://github.com/jariz/vibrant.js/releases/)
-####npm
+#### npm
 `npm install node-vibrant`  
 This is a node compatible version made by [AKFish](https://github.com/akfish), [more info & docs](https://github.com/akfish/node-vibrant).
 
-##Building
+## Building
 1. `npm install`
 1. `bower install`
 1. Compile gulpfile: `coffee -c gulpfile.coffee`
 2. `gulp`
 3. Done. Optionally run `gulp watch` for automatic compiling.
 
-##Other cool stuff
+## Other cool stuff
 Check out [Tabbie](http://github.com/jariz/tabbie), the fully customisable material new tab page, with all your favorite websites and services!  
 
 [![](https://cloud.githubusercontent.com/assets/1415847/7971420/f3dec05a-0a44-11e5-8ecb-fcac49e91f50.png)](http://github.com/jariz/tabbie)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
